### PR TITLE
Edit broadcast declaration in index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.mainBroadcastListener = mainBroadcastListener;
-exports.default = broadcast;
+exports.broadcast = broadcast;
 function mainBroadcastListener() {
   const { ipcMain } = require('electron');
 


### PR DESCRIPTION
The line "exports.default = broadcast" needs to change to "exports.broadcast = broadcast" in the index.js, otherwise I get the error that "broadcast is not a function" when I try to use it.
Let me know if you need more information/clarification.